### PR TITLE
Use CalVer as release version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Version increment
+      id: release_version
+      uses: reecetech/version-increment@main
+      with:
+        scheme: calver
     - name: Try building
       env: 
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -36,6 +41,7 @@ jobs:
         TG_THREAD_ID: ${{ secrets.TG_THREAD_ID }}
         KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
+        RELEASE_VERSION: ${{ steps.release_version.outputs.v-version }}
       run: |
         mkdir -p bins
         python main.py

--- a/main.py
+++ b/main.py
@@ -72,7 +72,6 @@ def main():
     build_apks(latest_version)
 
     publish_release(
-        latest_version.version,
         [
             f"x-piko-v{latest_version.version}.apk",
             f"x-piko-material-you-v{latest_version.version}.apk",

--- a/utils.py
+++ b/utils.py
@@ -136,12 +136,14 @@ def patch_apk(
         shutil.move(cli_output, out)
 
 
-def publish_release(tag: str, files: list[str]):
+def publish_release(files: list[str]):
     key = os.environ.get("GH_TOKEN")
     if key is None:
         raise Exception("GH_TOKEN is not set")
 
-    command = ["gh", "release", "create", "--latest", tag]
+    release_version = os.environ["RELEASE_VERSION"]
+
+    command = ["gh", "release", "create", "--latest", release_version]
 
     if len(files) == 0:
         raise Exception("Files should have atleast one item")


### PR DESCRIPTION
To avoid conflict when building the same twitter version with different patches and/or integrations version