### PR TITLE
Fix 'No new version found' when trying to build the first time on forked repository

### DIFF
--- a/github.py
+++ b/github.py
@@ -20,7 +20,7 @@ def count_releases(repo_url: str) -> int | None:
     url = f"https://api.github.com/repos/{repo_url}/releases"
     response = requests.get(url, headers=HEADERS)
 
-    print("get count releases of " + repo_url + ": " + str(response.status_code))
+    print("Get count releases of " + repo_url + ": " + str(response.status_code))
     if response.status_code == 200:
         release = response.json()
 
@@ -34,7 +34,7 @@ def get_last_build_version(repo_url: str) -> GithubRelease | None:
     url = f"https://api.github.com/repos/{repo_url}/releases/latest"
     response = requests.get(url, headers=HEADERS)
 
-    print("get latest releases of " + repo_url + ": " + str(response.status_code))
+    print("Get latest releases of " + repo_url + ": " + str(response.status_code))
     if response.status_code == 200:
         release = response.json()
 

--- a/github.py
+++ b/github.py
@@ -24,6 +24,7 @@ def count_releases(repo_url: str) -> int | None:
     if response.status_code == 200:
         release = response.json()
 
+        print(str(len(release)))
         if len(release) == 0:
             return 0
     elif response.status_code == 404:

--- a/github.py
+++ b/github.py
@@ -24,7 +24,6 @@ def count_releases(repo_url: str) -> int | None:
     if response.status_code == 200:
         release = response.json()
 
-        print(str(len(release)))
         if len(release) == 0:
             return 0
     elif response.status_code == 404:

--- a/github.py
+++ b/github.py
@@ -16,11 +16,25 @@ class GithubRelease:
     assets: list[Asset]
 
 
+def count_releases(repo_url: str) -> int | None:
+    url = f"https://api.github.com/repos/{repo_url}/releases"
+    response = requests.get(url, headers=HEADERS)
+
+    print("get count releases of " + repo_url + ": " + str(response.status_code))
+    if response.status_code == 200:
+        release = response.json()
+
+        if len(release) == 0:
+            return 0
+    elif response.status_code == 404:
+        return
+
+
 def get_last_build_version(repo_url: str) -> GithubRelease | None:
     url = f"https://api.github.com/repos/{repo_url}/releases/latest"
     response = requests.get(url, headers=HEADERS)
 
-    print("release " + repo_url + ": " + str(response.status_code))
+    print("get latest releases of " + repo_url + ": " + str(response.status_code))
     if response.status_code == 200:
         release = response.json()
 

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ def get_latest_release(versions: list[Version]) -> Version | None:
 def main():
     # get latest version
     url: str = "https://www.apkmirror.com/apk/x-corp/twitter/"
-    repo_url: str = "crimera/twitter-apk"
+    repo_url: str = os.environ["CURRENT_REPOSITORY"]
 
     versions = apkmirror.get_versions(url)
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ def main():
     url: str = "https://www.apkmirror.com/apk/x-corp/twitter/"
     repo_url = os.environ["CURRENT_REPOSITORY"]
 
+    print(str(repo_url))
+
     versions = apkmirror.get_versions(url)
 
     latest_version = get_latest_release(versions)

--- a/main.py
+++ b/main.py
@@ -37,8 +37,14 @@ def main():
         panic("Failed to fetch the latest build version")
         return
 
+    count_releases: int | None = github.count_releases(
+        repo_url
+    )
+
     # Begin stuff
-    if last_build_version.tag_name != latest_version.version:
+    if count_releases == 0:
+        print("First tim building!")
+    elif last_build_version.tag_name != latest_version.version:
         print(f"New version found: {latest_version.version}")
     else:
         print("No new version found")

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ def get_latest_release(versions: list[Version]) -> Version | None:
 def main():
     # get latest version
     url: str = "https://www.apkmirror.com/apk/x-corp/twitter/"
-    repo_url: str = os.environ["CURRENT_REPOSITORY"]
+    repo_url = os.environ["CURRENT_REPOSITORY"]
 
     versions = apkmirror.get_versions(url)
 

--- a/main.py
+++ b/main.py
@@ -35,13 +35,12 @@ def main():
     last_build_version: github.GithubRelease | None = github.get_last_build_version(
         repo_url
     )
-    if last_build_version is None:
-        panic("Failed to fetch the latest build version")
-        return
-
     count_releases: int | None = github.count_releases(
         repo_url
     )
+    if last_build_version is None and count_releases is None:
+        panic("Failed to fetch the latest build version")
+        return
 
     # Begin stuff
     if count_releases == 0:

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ def get_latest_release(versions: list[Version]) -> Version | None:
 def main():
     # get latest version
     url: str = "https://www.apkmirror.com/apk/x-corp/twitter/"
-    repo_url = os.environ["CURRENT_REPOSITORY"]
+    repo_url: str = os.environ["CURRENT_REPOSITORY"]
 
     print(str(repo_url))
 

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def main():
 
     # Begin stuff
     if count_releases == 0:
-        print("First tim building!")
+        print("First time building Piko Twitter!")
     elif last_build_version.tag_name != latest_version.version:
         print(f"New version found: {latest_version.version}")
     else:

--- a/utils.py
+++ b/utils.py
@@ -29,7 +29,8 @@ def report_to_telegram():
     tg_token = os.environ["TG_TOKEN"]
     tg_chat_id = os.environ["TG_CHAT_ID"]
     tg_thread_id = os.environ["TG_THREAD_ID"]
-    release = get_last_build_version("crimera/twitter-apk")
+    repo_url: str = os.environ["CURRENT_REPOSITORY"]
+    release = get_last_build_version(repo_url)
 
     if release is None:
         raise Exception("Could not fetch release")

--- a/utils.py
+++ b/utils.py
@@ -29,7 +29,7 @@ def report_to_telegram():
     tg_token = os.environ["TG_TOKEN"]
     tg_chat_id = os.environ["TG_CHAT_ID"]
     tg_thread_id = os.environ["TG_THREAD_ID"]
-    repo_url = os.environ["CURRENT_REPOSITORY"]
+    repo_url: str = os.environ["CURRENT_REPOSITORY"]
     release = get_last_build_version(repo_url)
 
     if release is None:

--- a/utils.py
+++ b/utils.py
@@ -29,7 +29,7 @@ def report_to_telegram():
     tg_token = os.environ["TG_TOKEN"]
     tg_chat_id = os.environ["TG_CHAT_ID"]
     tg_thread_id = os.environ["TG_THREAD_ID"]
-    repo_url: str = os.environ["CURRENT_REPOSITORY"]
+    repo_url = os.environ["CURRENT_REPOSITORY"]
     release = get_last_build_version(repo_url)
 
     if release is None:


### PR DESCRIPTION
This PR solves the problem when trying to build on a forked repository without any releases yet by adding checks for releases json length and removing hard-coded repo_url.